### PR TITLE
fix: added count parameter to retrieve all group members

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/rocketchat/RocketChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/rocketchat/RocketChatService.java
@@ -60,6 +60,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * Service for Rocket.Chat functionalities.
@@ -480,7 +481,7 @@ public class RocketChatService {
       HttpHeaders header = getStandardHttpHeaders(systemUser);
       HttpEntity<GroupAddUserBodyDTO> request = new HttpEntity<>(header);
 
-      response = restTemplate.exchange(rocketChatApiGetGroupMembersUrl + "?roomId=" + rcGroupId,
+      response = restTemplate.exchange(buildGetGroupMembersPath(rcGroupId),
           HttpMethod.GET, request, GroupMemberResponseDTO.class);
 
     } catch (Exception ex) {
@@ -494,6 +495,14 @@ public class RocketChatService {
       String error = "Could not get Rocket.Chat group members for room id %s";
       throw new RocketChatGetGroupMembersException(String.format(error, rcGroupId));
     }
+  }
+
+  private String buildGetGroupMembersPath(String rcGroupId) {
+    return UriComponentsBuilder
+        .fromUriString(rocketChatApiGetGroupMembersUrl)
+        .queryParam("roomId", rcGroupId)
+        .queryParam("count", 0)
+        .build().encode().toUriString();
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/testHelper/FieldConstants.java
+++ b/src/test/java/de/caritas/cob/userservice/testHelper/FieldConstants.java
@@ -30,6 +30,8 @@ public class FieldConstants {
       "rocketChatApiGroupCreateUrl";
   public static final String FIELD_NAME_ROCKET_CHAT_API_GROUP_DELETE_URL =
       "rocketChatApiGroupDeleteUrl";
+  public static final String FIELD_NAME_ROCKET_CHAT_API_GET_GROUP_MEMBERS =
+      "rocketChatApiGetGroupMembersUrl";
   public static final String FIELD_NAME_ROCKET_CHAT_API_SUBSCRIPTIONS_GET_URL =
       "rocketChatApiSubscriptionsGet";
   public static final String FIELD_NAME_ROCKET_CHAT_API_ROOMS_GET_URL = "rocketChatApiRoomsGet";
@@ -46,13 +48,12 @@ public class FieldConstants {
       "rocketChatApiCleanRoomHistory";
   public static final String FIELD_NAME_ROCKET_CHAT_TECH_AUTH_TOKEN = "technUserAuthToken";
   public static final String FIELD_NAME_ROCKET_CHAT_TECH_USER_ID = "technUserId";
-  public static final String FIELD_NAME_ROCKET_CHAT_SYSTEM_AUTH_TOKEN = "systemUserAuthToken";
-  public static final String FIELD_NAME_ROCKET_CHAT_SERVICE_SYSTEM_USER_ID = "systemUserId";
   public static final String FIELD_NAME_ROCKET_CHAT_API_USER_INFO = "rocketChatApiUserInfo";
 
   public static final String RC_URL_GROUPS_CREATE = "http://localhost/api/v1/groups.create";
   public static final String RC_URL_GROUPS_DELETE = "http://localhost/api/v1/groups.delete";
   public static final String RC_URL_GROUPS_REMOVE_USER = "http://localhost/api/v1/groups.kick";
+  public static final String RC_URL_GROUPS_MEMBERS_GET = "http://localhost/api/v1/groups.members";
   public static final String RC_URL_CHAT_USER_LOGIN = "http://localhost/api/v1/login";
   public static final String RC_URL_CHAT_USER_LOGOUT = "http://localhost/api/v1/logout";
   public static final String RC_URL_CHAT_ADD_USER = "http://localhost/api/v1/groups.invite";


### PR DESCRIPTION
Fixes the problem that when accepting a session on agencies with more than 50 consultants not all consultants had been removed from the corresponding Rocket.Chat room.
Added count parameter to the Rocket.Chat call so that all consultants are being received for removal.