### PR TITLE
fix: prevent rocket chat user deletion when id is not available

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/deleteworkflow/action/DeleteRocketChatUserAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/deleteworkflow/action/DeleteRocketChatUserAction.java
@@ -50,6 +50,22 @@ public class DeleteRocketChatUserAction implements DeleteAskerAction, DeleteCons
     return emptyList();
   }
 
+  /**
+   * Deletes the given {@link Consultant} related Rocket.Chat account.
+   *
+   * @param consultant the {@link Consultant}
+   * @return a possible generated {@link DeletionWorkflowError}
+   */
+  @Override
+  public List<DeletionWorkflowError> execute(Consultant consultant) {
+    try {
+      deleteUserInRocketChat(consultant.getRocketChatId());
+    } catch (Exception e) {
+      return buildErrorsForSourceType(CONSULTANT, consultant.getRocketChatId(), e);
+    }
+    return emptyList();
+  }
+
   private void deleteUserInRocketChat(String rcUserId) throws RocketChatDeleteUserException {
     if (isNotBlank(rcUserId)) {
       this.rocketChatService.deleteUser(rcUserId);
@@ -68,22 +84,6 @@ public class DeleteRocketChatUserAction implements DeleteAskerAction, DeleteCons
             .timestamp(nowInUtc())
             .build()
     );
-  }
-
-  /**
-   * Deletes the given {@link Consultant} related Rocket.Chat account.
-   *
-   * @param consultant the {@link Consultant}
-   * @return a possible generated {@link DeletionWorkflowError}
-   */
-  @Override
-  public List<DeletionWorkflowError> execute(Consultant consultant) {
-    try {
-      deleteUserInRocketChat(consultant.getRocketChatId());
-    } catch (Exception e) {
-      return buildErrorsForSourceType(CONSULTANT, consultant.getRocketChatId(), e);
-    }
-    return emptyList();
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/deleteworkflow/action/DeleteRocketChatUserAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/deleteworkflow/action/DeleteRocketChatUserAction.java
@@ -7,10 +7,13 @@ import static de.caritas.cob.userservice.api.deleteworkflow.model.DeletionTarget
 import static de.caritas.cob.userservice.localdatetime.CustomLocalDateTime.nowInUtc;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import de.caritas.cob.userservice.api.deleteworkflow.action.asker.DeleteAskerAction;
 import de.caritas.cob.userservice.api.deleteworkflow.action.consultant.DeleteConsultantAction;
+import de.caritas.cob.userservice.api.deleteworkflow.model.DeletionSourceType;
 import de.caritas.cob.userservice.api.deleteworkflow.model.DeletionWorkflowError;
+import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatDeleteUserException;
 import de.caritas.cob.userservice.api.repository.consultant.Consultant;
 import de.caritas.cob.userservice.api.repository.user.User;
 import de.caritas.cob.userservice.api.service.LogService;
@@ -40,20 +43,31 @@ public class DeleteRocketChatUserAction implements DeleteAskerAction, DeleteCons
   @Override
   public List<DeletionWorkflowError> execute(User user) {
     try {
-      this.rocketChatService.deleteUser(user.getRcUserId());
+      deleteUserInRocketChat(user.getRcUserId());
     } catch (Exception e) {
-      LogService.logDeleteWorkflowError(e);
-      return singletonList(
+      return buildErrorsForSourceType(ASKER, user.getRcUserId(), e);
+    }
+    return emptyList();
+  }
+
+  private void deleteUserInRocketChat(String rcUserId) throws RocketChatDeleteUserException {
+    if (isNotBlank(rcUserId)) {
+      this.rocketChatService.deleteUser(rcUserId);
+    }
+  }
+
+  private List<DeletionWorkflowError> buildErrorsForSourceType(
+      DeletionSourceType deletionSourceType, String rcUserId, Exception e) {
+    LogService.logDeleteWorkflowError(e);
+    return singletonList(
         DeletionWorkflowError.builder()
-            .deletionSourceType(ASKER)
+            .deletionSourceType(deletionSourceType)
             .deletionTargetType(ROCKET_CHAT)
-            .identifier(user.getRcUserId())
+            .identifier(rcUserId)
             .reason(ERROR_REASON)
             .timestamp(nowInUtc())
             .build()
-      );
-    }
-    return emptyList();
+    );
   }
 
   /**
@@ -65,18 +79,9 @@ public class DeleteRocketChatUserAction implements DeleteAskerAction, DeleteCons
   @Override
   public List<DeletionWorkflowError> execute(Consultant consultant) {
     try {
-      this.rocketChatService.deleteUser(consultant.getRocketChatId());
+      deleteUserInRocketChat(consultant.getRocketChatId());
     } catch (Exception e) {
-      LogService.logDeleteWorkflowError(e);
-      return singletonList(
-          DeletionWorkflowError.builder()
-              .deletionSourceType(CONSULTANT)
-              .deletionTargetType(ROCKET_CHAT)
-              .identifier(consultant.getRocketChatId())
-              .reason(ERROR_REASON)
-              .timestamp(nowInUtc())
-              .build()
-      );
+      return buildErrorsForSourceType(CONSULTANT, consultant.getRocketChatId(), e);
     }
     return emptyList();
   }

--- a/src/test/java/de/caritas/cob/userservice/api/deleteworkflow/action/DeleteRocketChatUserActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/deleteworkflow/action/DeleteRocketChatUserActionTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.powermock.reflect.Whitebox.setInternalState;
 
 import de.caritas.cob.userservice.api.deleteworkflow.model.DeletionWorkflowError;
@@ -53,13 +54,23 @@ public class DeleteRocketChatUserActionTest {
   }
 
   @Test
-  public void execute_Should_deleteRocketCHatUserAndReturnEmptyList_When_userDeletionIsSuccessful()
+  public void execute_Should_deleteRocketChatUserAndReturnEmptyList_When_userDeletionIsSuccessful()
       throws RocketChatDeleteUserException {
+    User user = new User();
+    user.setRcUserId("rcId");
+    List<DeletionWorkflowError> workflowErrors = this.deleteRocketChatUserAction.execute(user);
+
+    assertThat(workflowErrors, hasSize(0));
+    verify(this.rocketChatService, times(1)).deleteUser(any());
+  }
+
+  @Test
+  public void execute_Should_notDeleteRocketChatUserAndReturnEmptyList_When_userHasNoRcId() {
     List<DeletionWorkflowError> workflowErrors = this.deleteRocketChatUserAction
         .execute(new User());
 
     assertThat(workflowErrors, hasSize(0));
-    verify(this.rocketChatService, times(1)).deleteUser(any());
+    verifyNoInteractions(this.rocketChatService);
   }
 
   @Test
@@ -83,11 +94,22 @@ public class DeleteRocketChatUserActionTest {
   @Test
   public void execute_Should_deleteRocketChatUserAndReturnEmptyList_When_consultantDeletionIsSuccessful()
       throws RocketChatDeleteUserException {
+    Consultant consultant = new Consultant();
+    consultant.setRocketChatId("rcId");
+    List<DeletionWorkflowError> workflowErrors = this.deleteRocketChatUserAction
+        .execute(consultant);
+
+    assertThat(workflowErrors, hasSize(0));
+    verify(this.rocketChatService, times(1)).deleteUser(any());
+  }
+
+  @Test
+  public void execute_Should_notDeleteRocketChatUserAndReturnEmptyList_When_consultantHasNoRcId() {
     List<DeletionWorkflowError> workflowErrors = this.deleteRocketChatUserAction
         .execute(new Consultant());
 
     assertThat(workflowErrors, hasSize(0));
-    verify(this.rocketChatService, times(1)).deleteUser(any());
+    verifyNoInteractions(this.rocketChatService);
   }
 
   @Test


### PR DESCRIPTION
## Trigger deletion of rocket chat user account only when a rocket chat user id is present